### PR TITLE
feat: add prettier CLI and comprehensive prettier tests

### DIFF
--- a/packages/vite-plugin/src/prettier-cli.ts
+++ b/packages/vite-plugin/src/prettier-cli.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * CLI for formatting TypeScript files with effect-sugar gen {} syntax
+ *
+ * Usage:
+ *   effect-sugar-prettier [files...]
+ *   effect-sugar-prettier --write [files...]
+ *   effect-sugar-prettier --check [files...]
+ */
+
+import { Effect, Console, Array as Arr } from 'effect'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { globSync } from 'glob'
+import { formatWithEffectSugar } from './prettier.js'
+
+interface CLIOptions {
+  write: boolean
+  check: boolean
+  patterns: string[]
+}
+
+const parseArgs = (args: string[]): CLIOptions => {
+  const options: CLIOptions = {
+    write: false,
+    check: false,
+    patterns: []
+  }
+
+  for (const arg of args) {
+    if (arg === '--write' || arg === '-w') {
+      options.write = true
+    } else if (arg === '--check' || arg === '-c') {
+      options.check = true
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    } else if (!arg.startsWith('-')) {
+      options.patterns.push(arg)
+    }
+  }
+
+  return options
+}
+
+const printHelp = (): void => {
+  console.log(`
+effect-sugar-prettier - Format TypeScript with gen {} syntax
+
+Usage:
+  effect-sugar-prettier [options] [files/patterns...]
+
+Options:
+  --write, -w   Write formatted output back to files
+  --check, -c   Check if files are formatted (exit 1 if not)
+  --help, -h    Show this help message
+
+Examples:
+  # Format and print to stdout
+  effect-sugar-prettier src/index.ts
+
+  # Format and write back to file
+  effect-sugar-prettier --write src/index.ts
+
+  # Format all TS files with glob pattern
+  effect-sugar-prettier --write 'src/**/*.ts'
+
+  # Check formatting (for CI)
+  effect-sugar-prettier --check 'src/**/*.ts'
+
+  # With lint-staged
+  "lint-staged": {
+    "*.ts": "effect-sugar-prettier --write"
+  }
+`)
+}
+
+const expandGlobs = (patterns: string[]): string[] => {
+  const files: string[] = []
+
+  for (const pattern of patterns) {
+    if (pattern.includes('*') || pattern.includes('?') || pattern.includes('[')) {
+      const matches = globSync(pattern, { cwd: process.cwd() })
+      files.push(...matches)
+    } else if (fs.existsSync(pattern) && fs.statSync(pattern).isFile()) {
+      files.push(pattern)
+    }
+  }
+
+  return files
+}
+
+const formatFile = (filepath: string, options: CLIOptions): Effect.Effect<boolean, Error> =>
+  Effect.gen(function* () {
+    const absolutePath = path.resolve(filepath)
+    const source = fs.readFileSync(absolutePath, 'utf-8')
+
+    const formatted = yield* formatWithEffectSugar(source, { filepath: absolutePath }).pipe(
+      Effect.mapError((e) => new Error(`Format failed: ${e.message}`))
+    )
+
+    if (options.check) {
+      if (source !== formatted) {
+        yield* Console.error(`File not formatted: ${filepath}`)
+        return false
+      }
+      return true
+    }
+
+    if (options.write) {
+      if (source !== formatted) {
+        fs.writeFileSync(absolutePath, formatted, 'utf-8')
+        yield* Console.log(`Formatted: ${filepath}`)
+      }
+    } else {
+      process.stdout.write(formatted)
+    }
+
+    return true
+  })
+
+const main = Effect.gen(function* () {
+  const args = process.argv.slice(2)
+
+  if (args.length === 0) {
+    printHelp()
+    return yield* Effect.fail(new Error('No arguments'))
+  }
+
+  const options = parseArgs(args)
+
+  if (options.patterns.length === 0) {
+    yield* Console.error('No files specified')
+    return yield* Effect.fail(new Error('No files specified'))
+  }
+
+  const files = expandGlobs(options.patterns)
+
+  if (files.length === 0) {
+    yield* Console.error('No matching files found')
+    return yield* Effect.fail(new Error('No matching files found'))
+  }
+
+  const results = yield* Effect.forEach(files, (file) => formatFile(file, options), {
+    concurrency: 'unbounded'
+  })
+
+  const allPassed = Arr.every(results, (r) => r === true)
+
+  if (!allPassed) {
+    return yield* Effect.fail(new Error('Some files failed'))
+  }
+})
+
+Effect.runPromise(main).catch((error) => {
+  console.error('Error:', error)
+  process.exit(1)
+})

--- a/packages/vite-plugin/test/prettier.test.ts
+++ b/packages/vite-plugin/test/prettier.test.ts
@@ -1,0 +1,619 @@
+import { describe, it, expect } from 'vitest'
+import { Effect } from 'effect'
+import {
+  hasEffectGen,
+  findEffectGenBlocks,
+  reverseTransformContent,
+  reverseTransformSource,
+  formatWithEffectSugar
+} from '../src/prettier.js'
+
+// Marker used by transformation to identify gen {} blocks
+const MARKER = '/* __EFFECT_SUGAR__ */'
+
+describe('hasEffectGen', () => {
+  it('returns true for marked Effect.gen', () => {
+    expect(hasEffectGen(`const x = Effect.gen(${MARKER} function* () { return 1 })`)).toBe(true)
+  })
+
+  it('returns false for unmarked Effect.gen', () => {
+    // Standard Effect.gen should NOT be detected (no marker)
+    expect(hasEffectGen('const x = Effect.gen(function* () { return 1 })')).toBe(false)
+  })
+
+  it('returns false for source without Effect.gen', () => {
+    expect(hasEffectGen('const x = 1')).toBe(false)
+  })
+
+  it('returns false for partial matches', () => {
+    expect(hasEffectGen('Effect.generate()')).toBe(false)
+    expect(hasEffectGen('MyEffect.gen()')).toBe(false)
+  })
+})
+
+describe('findEffectGenBlocks', () => {
+  it('finds a marked Effect.gen block', () => {
+    const source = `const x = Effect.gen(${MARKER} function* () { return 1 })`
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].bodyContent).toBe(' return 1 ')
+  })
+
+  it('ignores unmarked Effect.gen blocks', () => {
+    // Standard Effect.gen without marker should NOT be found
+    const source = 'const x = Effect.gen(function* () { return 1 })'
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(0)
+  })
+
+  it('finds multiple marked Effect.gen blocks', () => {
+    const source = `
+const a = Effect.gen(${MARKER} function* () { return 1 })
+const b = Effect.gen(${MARKER} function* () { return 2 })
+`
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(2)
+  })
+
+  it('handles nested braces in expressions', () => {
+    const source = `Effect.gen(${MARKER} function* () { const x = yield* Effect.succeed({ a: 1 }) })`
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].bodyContent).toContain('yield* Effect.succeed({ a: 1 })')
+  })
+
+  it('handles strings with braces', () => {
+    const source = `Effect.gen(${MARKER} function* () { const x = yield* Effect.succeed("{not a block}") })`
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].bodyContent).toContain('"{not a block}"')
+  })
+
+  it('handles multiline marked Effect.gen', () => {
+    const source = `const program = Effect.gen(${MARKER} function* () {
+  const user = yield* getUser(id)
+  return user
+})`
+    const blocks = findEffectGenBlocks(source)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].bodyContent).toContain('const user = yield* getUser(id)')
+  })
+})
+
+describe('reverseTransformContent', () => {
+  it('transforms yield* back to bind arrow', () => {
+    const input = '  const user = yield* getUser(id)'
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe('  user <- getUser(id)')
+  })
+
+  it('transforms yield* with semicolons', () => {
+    const input = '  const user = yield* getUser(id);'
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe('  user <- getUser(id);')
+  })
+
+  it('preserves const for non-yield expressions', () => {
+    const input = '  const name = user.name'
+    const output = reverseTransformContent(input)
+
+    // We intentionally keep const as-is to avoid breaking nested functions/callbacks
+    expect(output).toBe('  const name = user.name')
+  })
+
+  it('preserves return statements', () => {
+    const input = '  return { user, name }'
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe('  return { user, name }')
+  })
+
+  it('preserves comments', () => {
+    const input = `  // Get the user
+  const user = yield* getUser(id)`
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe(`  // Get the user
+  user <- getUser(id)`)
+  })
+
+  it('preserves empty lines', () => {
+    const input = `  const user = yield* getUser(id)
+
+  return user`
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe(`  user <- getUser(id)
+
+  return user`)
+  })
+
+  it('handles complex multiline content', () => {
+    const input = `
+  const user = yield* getUser(id)
+  const profile = yield* getProfile(user.id)
+  const name = user.name.toUpperCase()
+  return { user, profile, name }
+`
+    const output = reverseTransformContent(input)
+
+    expect(output).toBe(`
+  user <- getUser(id)
+  profile <- getProfile(user.id)
+  const name = user.name.toUpperCase()
+  return { user, profile, name }
+`)
+  })
+})
+
+describe('reverseTransformSource', () => {
+  it('transforms marked Effect.gen back to gen block', () => {
+    const source = `const x = Effect.gen(${MARKER} function* () { return 1 })`
+    const result = reverseTransformSource(source)
+
+    expect(result).toBe('const x = gen { return 1 }')
+  })
+
+  it('ignores unmarked Effect.gen', () => {
+    // Standard Effect.gen should NOT be reverse-transformed
+    const source = 'const x = Effect.gen(function* () { return 1 })'
+    const result = reverseTransformSource(source)
+
+    // Should be unchanged
+    expect(result).toBe(source)
+  })
+
+  it('transforms yield* back to bind arrow', () => {
+    const source = `const program = Effect.gen(${MARKER} function* () {
+  const user = yield* getUser(id)
+  return user
+})`
+    const result = reverseTransformSource(source)
+
+    expect(result).toBe(`const program = gen {
+  user <- getUser(id)
+  return user
+}`)
+  })
+
+  it('preserves const in body', () => {
+    const source = `const program = Effect.gen(${MARKER} function* () {
+  const x = 1
+  return x
+})`
+    const result = reverseTransformSource(source)
+
+    expect(result).toBe(`const program = gen {
+  const x = 1
+  return x
+}`)
+  })
+
+  it('transforms multiple marked Effect.gen blocks', () => {
+    const source = `
+const a = Effect.gen(${MARKER} function* () { return 1 })
+const b = Effect.gen(${MARKER} function* () { return 2 })
+`
+    const result = reverseTransformSource(source)
+
+    expect(result).toBe(`
+const a = gen { return 1 }
+const b = gen { return 2 }
+`)
+  })
+
+  it('preserves code outside marked Effect.gen blocks', () => {
+    const source = `import { Effect } from 'effect'
+
+const helper = (x: number) => x * 2
+
+const program = Effect.gen(${MARKER} function* () {
+  return helper(21)
+})
+
+export { program }
+`
+    const result = reverseTransformSource(source)
+
+    expect(result).toContain("import { Effect } from 'effect'")
+    expect(result).toContain('const helper = (x: number) => x * 2')
+    expect(result).toContain('gen {')
+    expect(result).toContain('export { program }')
+  })
+
+  it('returns unchanged source when no marked Effect.gen blocks', () => {
+    const source = 'const x = 1'
+    const result = reverseTransformSource(source)
+
+    expect(result).toBe(source)
+  })
+})
+
+describe('round-trip transformation', () => {
+  it('maintains code structure through transform and reverse', async () => {
+    const original = `const program = gen {
+  user <- getUser(id)
+  profile <- getProfile(user.id)
+  const name = user.name.toUpperCase()
+  return { user, profile, name }
+}`
+
+    // This test verifies the round-trip without actually calling Prettier
+    // (which would change formatting)
+    // Note: `let` statements become `const` after transformation, which is intentional
+    const { transformSource } = await import('../src/transform.js')
+
+    const transformed = transformSource(original)
+    expect(transformed.hasChanges).toBe(true)
+
+    const reversed = reverseTransformSource(transformed.code)
+    expect(reversed).toBe(original)
+  })
+
+  it('preserves let declarations (not converted to const)', async () => {
+    // let declarations are now preserved to avoid breaking nested callbacks
+    // See: tmp/2025-11-25/NESTED_CALLBACK_LET_BUG.md
+    const original = `const program = gen {
+  let name = user.name
+  return name
+}`
+    const expected = `const program = gen {
+  let name = user.name
+  return name
+}`
+
+    const { transformSource } = await import('../src/transform.js')
+
+    const transformed = transformSource(original)
+    const reversed = reverseTransformSource(transformed.code)
+    expect(reversed).toBe(expected)
+  })
+})
+
+describe('formatWithEffectSugar', () => {
+  it('formats gen blocks and converts back', async () => {
+    // Simple case - formatting should add semicolons and proper spacing
+    const source = `const x = gen {
+  user <- getUser(id)
+  return user
+}`
+
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript',
+        semi: true
+      })
+    )
+
+    // Should contain gen {} syntax (not Effect.gen)
+    expect(formatted).toContain('gen {')
+    expect(formatted).toContain('<-')
+    expect(formatted).not.toContain('Effect.gen')
+    expect(formatted).not.toContain('yield*')
+  })
+
+  it('handles files without gen blocks', async () => {
+    const source = 'const x = 1'
+
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    // Should just format normally
+    expect(formatted).toContain('const x = 1')
+  })
+
+  it('handles complex gen blocks with nested objects', async () => {
+    const source = `const program = gen {
+  config <- Effect.succeed({
+    api: { url: "https://api.example.com" },
+    timeout: 5000
+  })
+  return config
+}`
+
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('gen {')
+    expect(formatted).toContain('<-')
+    expect(formatted).toContain('api: { url:')
+  })
+})
+
+// ============================================================================
+// CRITICAL: Tests for files that should NOT be modified (except formatting)
+// ============================================================================
+
+describe('files without gen {} syntax should be preserved', () => {
+  it('preserves standard Effect.gen syntax unchanged', async () => {
+    const source = `import { Effect } from 'effect'
+
+const program = Effect.gen(function* () {
+  const user = yield* getUser(id)
+  return user
+})
+
+export { program }
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    // Should still have Effect.gen (NOT converted to gen {})
+    expect(formatted).toContain('Effect.gen(function* ()')
+    expect(formatted).toContain('yield*')
+    // Should NOT have gen {} syntax
+    expect(formatted).not.toMatch(/\bgen\s*\{/)
+    expect(formatted).not.toContain('<-')
+  })
+
+  it('preserves complex TypeScript with generics', async () => {
+    const source = `interface Result<T, E> {
+  data: T
+  error: E | null
+}
+
+const process = <T extends Record<string, unknown>>(input: T): Result<T, Error> => {
+  return { data: input, error: null }
+}
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('interface Result<T, E>')
+    expect(formatted).toContain('<T extends Record<string, unknown>>')
+  })
+
+  it('preserves arrow functions and callbacks', async () => {
+    const source = `const items = [1, 2, 3]
+const doubled = items.map((x) => x * 2)
+const filtered = items.filter((x) => {
+  return x > 1
+})
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('map((x) => x * 2)')
+    expect(formatted).toContain('filter((x) =>')
+  })
+
+  it('preserves object destructuring', async () => {
+    const source = `const { a, b } = obj
+const [x, y] = arr
+const { nested: { deep } } = complex
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('const { a, b }')
+    expect(formatted).toContain('const [x, y]')
+    expect(formatted).toContain('nested: { deep }')
+  })
+
+  it('preserves type annotations and interfaces', async () => {
+    const source = `type Handler = (req: Request) => Response
+
+interface Config {
+  url: string
+  timeout: number
+}
+
+const config: Config = {
+  url: 'https://api.example.com',
+  timeout: 5000
+}
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('type Handler = (req: Request) => Response')
+    expect(formatted).toContain('interface Config')
+    expect(formatted).toContain('const config: Config')
+  })
+
+  it('preserves async/await syntax', async () => {
+    const source = `async function fetchData() {
+  const response = await fetch('/api')
+  const data = await response.json()
+  return data
+}
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('async function fetchData()')
+    expect(formatted).toContain('await fetch')
+    expect(formatted).toContain('await response.json()')
+  })
+
+  it('preserves class syntax', async () => {
+    const source = `class UserService {
+  private cache: Map<string, User> = new Map()
+
+  async getUser(id: string): Promise<User> {
+    return this.cache.get(id) ?? await this.fetchUser(id)
+  }
+}
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('class UserService')
+    expect(formatted).toContain('private cache: Map<string, User>')
+    expect(formatted).toContain('async getUser(id: string): Promise<User>')
+  })
+})
+
+// ============================================================================
+// Edge cases that could cause issues
+// ============================================================================
+
+describe('edge cases', () => {
+  it('handles files with "gen" in variable names', async () => {
+    const source = `const generator = () => 1
+const general = 'test'
+const generateId = () => Math.random()
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('const generator')
+    expect(formatted).toContain('const general')
+    expect(formatted).toContain('const generateId')
+    // Should not be converted to gen {} syntax
+    expect(formatted).not.toMatch(/\bgen\s*\{/)
+  })
+
+  it('handles "gen" in strings', async () => {
+    const source = `const msg = "use gen { } for effects"
+const template = \`gen { x <- foo() }\`
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    // String content should be preserved (Prettier may adjust whitespace)
+    expect(formatted).toContain('gen { }')
+    // Template literal - Prettier may remove trailing space before }
+    expect(formatted).toContain('gen { x <- foo()}')
+  })
+
+  it('handles nested Effect operations without gen {}', async () => {
+    const source = `const program = Effect.all([
+  Effect.succeed(1),
+  Effect.succeed(2)
+]).pipe(
+  Effect.map(([a, b]) => a + b)
+)
+`
+    const formatted = await Effect.runPromise(
+      formatWithEffectSugar(source, {
+        filepath: 'test.ts',
+        parser: 'typescript'
+      })
+    )
+
+    expect(formatted).toContain('Effect.all')
+    expect(formatted).toContain('Effect.succeed')
+    expect(formatted).toContain('Effect.map')
+    expect(formatted).not.toMatch(/\bgen\s*\{/)
+  })
+
+  it('handles destructuring in yield* (should preserve as-is)', async () => {
+    const source = `const program = gen {
+  const [a, b] = yield* Effect.all([getA(), getB()])
+  return a + b
+}`
+    // Note: Our current regex doesn't handle destructuring, so this passes through
+    const { transformSource } = await import('../src/transform.js')
+    const transformed = transformSource(source)
+    const reversed = reverseTransformSource(transformed.code)
+
+    // Destructuring patterns are preserved (not converted to <-)
+    expect(reversed).toContain('const [a, b] = yield*')
+  })
+
+  it('handles arrow functions inside gen blocks', async () => {
+    const source = `const program = gen {
+  items <- getItems()
+  const doubled = items.map(x => x * 2)
+  return doubled
+}`
+    const { transformSource } = await import('../src/transform.js')
+    const transformed = transformSource(source)
+    const reversed = reverseTransformSource(transformed.code)
+
+    expect(reversed).toContain('items <- getItems()')
+    expect(reversed).toContain('items.map(x => x * 2)')
+  })
+
+  it('handles try/catch inside gen blocks', async () => {
+    const source = `const program = gen {
+  result <- Effect.try({
+    try: () => JSON.parse(input),
+    catch: (e) => new ParseError(e)
+  })
+  return result
+}`
+    const { transformSource } = await import('../src/transform.js')
+    const transformed = transformSource(source)
+    const reversed = reverseTransformSource(transformed.code)
+
+    expect(reversed).toContain('result <- Effect.try')
+    expect(reversed).toContain('try: () => JSON.parse')
+    expect(reversed).toContain('catch: (e) => new ParseError')
+  })
+
+  it('handles multiline arrow functions in Effect.tryPromise', async () => {
+    const source = `const program = gen {
+  data <- Effect.tryPromise({
+    try: async () => {
+      const response = await fetch('/api')
+      return response.json()
+    },
+    catch: (error) => new NetworkError(String(error))
+  })
+  return data
+}`
+    const { transformSource } = await import('../src/transform.js')
+    const transformed = transformSource(source)
+    const reversed = reverseTransformSource(transformed.code)
+
+    expect(reversed).toContain('data <- Effect.tryPromise')
+    expect(reversed).toContain('try: async () => {')
+    expect(reversed).toContain('await fetch')
+    expect(reversed).toContain('catch: (error) => new NetworkError')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,12 @@ importers:
 
   packages/vite-plugin:
     dependencies:
+      effect:
+        specifier: ^3.12.0
+        version: 3.19.6
+      glob:
+        specifier: ^11.0.0
+        version: 11.1.0
       magic-string:
         specifier: ^0.30.5
         version: 0.30.21
@@ -76,6 +82,9 @@ importers:
       esbuild:
         specifier: ^0.27.0
         version: 0.27.0
+      prettier:
+        specifier: ^3.0.0
+        version: 3.6.2
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -583,6 +592,18 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -854,13 +875,25 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -976,8 +1009,15 @@ packages:
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1077,6 +1117,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -1085,6 +1128,12 @@ packages:
 
   electron-to-chromium@1.5.260:
     resolution: {integrity: sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -1182,6 +1231,10 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -1233,6 +1286,11 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -1322,6 +1380,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1353,6 +1415,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1435,6 +1501,10 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1488,11 +1558,19 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -1577,6 +1655,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -1607,6 +1688,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@2.0.1:
+    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
+    engines: {node: 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1795,12 +1880,24 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2021,6 +2118,14 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -2538,6 +2643,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.25
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -2809,11 +2929,19 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -2953,7 +3081,13 @@ snapshots:
     dependencies:
       color-name: 1.1.3
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
   color-name@1.1.3: {}
+
+  color-name@1.1.4: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -3045,6 +3179,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -3055,6 +3191,10 @@ snapshots:
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.260: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -3203,6 +3343,11 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -3263,6 +3408,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.1
 
   glob@7.2.3:
     dependencies:
@@ -3354,6 +3508,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -3377,6 +3533,10 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
 
   js-tokens@4.0.0: {}
 
@@ -3462,6 +3622,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  lru-cache@11.2.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3508,12 +3670,18 @@ snapshots:
   mimic-response@3.1.0:
     optional: true
 
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
 
   minimist@1.2.8:
     optional: true
+
+  minipass@7.1.2: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -3593,6 +3761,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -3621,6 +3791,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@2.0.1:
+    dependencies:
+      lru-cache: 11.2.2
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 
@@ -3833,6 +4008,18 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -3841,6 +4028,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -4034,6 +4225,18 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Add `effect-sugar-prettier` CLI for formatting files with gen {} syntax
- Refactor prettier.ts to use Effect for async operations
- Add comprehensive test suite (43 tests)

## Features

### CLI Usage
```bash
# Check formatting
effect-sugar-prettier --check "src/**/*.ts"

# Fix formatting
effect-sugar-prettier --write "src/**/*.ts"

# Use with lint-staged
{
  "lint-staged": {
    "*.ts": "effect-sugar-prettier --write"
  }
}
```

### Marker-Based Detection
The reverse transformation now uses a marker comment (`__EFFECT_SUGAR__`) to identify blocks that came from gen {} syntax. This means:
- Hand-written `Effect.gen()` blocks are **preserved** (not converted to gen {})
- Only blocks transformed by effect-sugar are converted back

## Test Plan

- [x] 43 new tests for prettier functionality
- [x] All tests pass
- [x] Tested round-trip transformation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
