### PR TITLE
fix: ignore examples from changesets and use workspace protocol

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["effect-sugar"]
+  "ignore": ["effect-sugar", "gen-block-examples"]
 }

--- a/examples/gen-block/package.json
+++ b/examples/gen-block/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "effect": "^3.19.8",
-    "effect-sugar-ts-plugin": "file:../../packages/vscode-extension/ts-plugin",
+    "effect-sugar-ts-plugin": "workspace:*",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "publish:dev": "pnpm publish:dev:vite",
     "publish:dev:vite": "pnpm --filter effect-sugar-vite publish:dev",
     "package:vscode": "pnpm --filter effect-sugar run package",
-    "setup:debug": "mkdir -p examples/gen-block/node_modules && cp -r packages/vscode-extension/ts-plugin examples/gen-block/node_modules/effect-sugar-ts-plugin && npm install --prefix examples/gen-block --silent effect typescript"
+    "setup:debug": "pnpm --filter gen-block-examples install && mkdir -p examples/gen-block/node_modules && cp -r packages/vscode-extension/ts-plugin examples/gen-block/node_modules/effect-sugar-ts-plugin"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^3.19.8
         version: 3.19.8
       effect-sugar-ts-plugin:
-        specifier: file:../../packages/vscode-extension/ts-plugin
+        specifier: workspace:*
         version: link:../../packages/vscode-extension/ts-plugin
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
## Summary

Fixes the changeset publish error:
```
Package "gen-block-examples" must depend on the current version of "effect-sugar-ts-plugin"
```

**Changes:**
- Add `gen-block-examples` to changeset ignore list (it's private, shouldn't publish)
- Use `workspace:*` instead of `file:` for ts-plugin dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)